### PR TITLE
Verify property layer backend mobile compatibility

### DIFF
--- a/yemen_booking_app/lib/features/search/presentation/bloc/search_bloc.dart
+++ b/yemen_booking_app/lib/features/search/presentation/bloc/search_bloc.dart
@@ -71,16 +71,19 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     }
 
     final params = SearchPropertiesParams(
-      searchQuery: event.searchQuery,
+      searchTerm: event.searchTerm,
       city: event.city,
-      propertyType: event.propertyType,
+      propertyTypeId: event.propertyTypeId,
       minPrice: event.minPrice,
       maxPrice: event.maxPrice,
-      minRating: event.minRating,
-      amenities: event.amenities,
-      checkInDate: event.checkInDate,
-      checkOutDate: event.checkOutDate,
-      guests: event.guests,
+      minStarRating: event.minStarRating,
+      requiredAmenities: event.requiredAmenities,
+      unitTypeId: event.unitTypeId,
+      serviceIds: event.serviceIds,
+      dynamicFieldFilters: event.dynamicFieldFilters,
+      checkIn: event.checkIn,
+      checkOut: event.checkOut,
+      guestsCount: event.guestsCount,
       latitude: event.latitude,
       longitude: event.longitude,
       radiusKm: event.radiusKm,
@@ -147,20 +150,23 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
         final nextPage = successState.searchResults.pageNumber + 1;
         
         add(SearchPropertiesEvent(
-          searchQuery: _currentFilters['searchQuery'],
-          city: _currentFilters['city'],
-          propertyType: _currentFilters['propertyType'],
-          minPrice: _currentFilters['minPrice'],
-          maxPrice: _currentFilters['maxPrice'],
-          minRating: _currentFilters['minRating'],
-          amenities: _currentFilters['amenities'],
-          checkInDate: _currentFilters['checkInDate'],
-          checkOutDate: _currentFilters['checkOutDate'],
-          guests: _currentFilters['guests'],
-          latitude: _currentFilters['latitude'],
-          longitude: _currentFilters['longitude'],
-          radiusKm: _currentFilters['radiusKm'],
-          sortBy: _currentFilters['sortBy'],
+          searchTerm: _currentFilters['searchTerm'] as String?,
+          city: _currentFilters['city'] as String?,
+          propertyTypeId: _currentFilters['propertyTypeId'] as String?,
+          minPrice: _currentFilters['minPrice'] as double?,
+          maxPrice: _currentFilters['maxPrice'] as double?,
+          minStarRating: _currentFilters['minStarRating'] as int?,
+          requiredAmenities: _currentFilters['requiredAmenities'] as List<String>?,
+          unitTypeId: _currentFilters['unitTypeId'] as String?,
+          serviceIds: _currentFilters['serviceIds'] as List<String>?,
+          dynamicFieldFilters: _currentFilters['dynamicFieldFilters'] as Map<String, dynamic>?,
+          checkIn: _currentFilters['checkIn'] as DateTime?,
+          checkOut: _currentFilters['checkOut'] as DateTime?,
+          guestsCount: _currentFilters['guestsCount'] as int?,
+          latitude: _currentFilters['latitude'] as double?,
+          longitude: _currentFilters['longitude'] as double?,
+          radiusKm: _currentFilters['radiusKm'] as double?,
+          sortBy: _currentFilters['sortBy'] as String?,
           pageNumber: nextPage,
           pageSize: successState.searchResults.pageSize,
           isNewSearch: false,
@@ -440,26 +446,33 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     Emitter<SearchState> emit,
   ) {
     add(SearchPropertiesEvent(
-      searchQuery: event.searchParams['searchQuery'],
-      city: event.searchParams['city'],
-      propertyType: event.searchParams['propertyType'],
-      minPrice: event.searchParams['minPrice'],
-      maxPrice: event.searchParams['maxPrice'],
-      minRating: event.searchParams['minRating'],
-      amenities: event.searchParams['amenities'] != null
-          ? List<String>.from(event.searchParams['amenities'])
+      searchTerm: event.searchParams['searchTerm'] as String?,
+      city: event.searchParams['city'] as String?,
+      propertyTypeId: event.searchParams['propertyTypeId'] as String?,
+      minPrice: event.searchParams['minPrice'] as double?,
+      maxPrice: event.searchParams['maxPrice'] as double?,
+      minStarRating: event.searchParams['minStarRating'] as int?,
+      requiredAmenities: event.searchParams['requiredAmenities'] != null
+          ? List<String>.from(event.searchParams['requiredAmenities'])
           : null,
-      checkInDate: event.searchParams['checkInDate'] != null
-          ? DateTime.parse(event.searchParams['checkInDate'])
+      unitTypeId: event.searchParams['unitTypeId'] as String?,
+      serviceIds: event.searchParams['serviceIds'] != null
+          ? List<String>.from(event.searchParams['serviceIds'])
           : null,
-      checkOutDate: event.searchParams['checkOutDate'] != null
-          ? DateTime.parse(event.searchParams['checkOutDate'])
+      dynamicFieldFilters: event.searchParams['dynamicFieldFilters'] != null
+          ? Map<String, dynamic>.from(event.searchParams['dynamicFieldFilters'])
           : null,
-      guests: event.searchParams['guests'],
-      latitude: event.searchParams['latitude'],
-      longitude: event.searchParams['longitude'],
-      radiusKm: event.searchParams['radiusKm'],
-      sortBy: event.searchParams['sortBy'],
+      checkIn: event.searchParams['checkIn'] != null
+          ? DateTime.parse(event.searchParams['checkIn'])
+          : null,
+      checkOut: event.searchParams['checkOut'] != null
+          ? DateTime.parse(event.searchParams['checkOut'])
+          : null,
+      guestsCount: event.searchParams['guestsCount'] as int?,
+      latitude: event.searchParams['latitude'] as double?,
+      longitude: event.searchParams['longitude'] as double?,
+      radiusKm: event.searchParams['radiusKm'] as double?,
+      sortBy: event.searchParams['sortBy'] as String?,
     ));
   }
 
@@ -467,30 +480,33 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     final filters = <String, dynamic>{};
     
     if (event is SearchPropertiesEvent) {
-      if (event.searchQuery != null) filters['searchQuery'] = event.searchQuery;
+      if (event.searchTerm != null) filters['searchTerm'] = event.searchTerm;
       if (event.city != null) filters['city'] = event.city;
-      if (event.propertyType != null) filters['propertyType'] = event.propertyType;
+      if (event.propertyTypeId != null) filters['propertyTypeId'] = event.propertyTypeId;
       if (event.minPrice != null) filters['minPrice'] = event.minPrice;
       if (event.maxPrice != null) filters['maxPrice'] = event.maxPrice;
-      if (event.minRating != null) filters['minRating'] = event.minRating;
-      if (event.amenities != null) filters['amenities'] = event.amenities;
-      if (event.checkInDate != null) filters['checkInDate'] = event.checkInDate;
-      if (event.checkOutDate != null) filters['checkOutDate'] = event.checkOutDate;
-      if (event.guests != null) filters['guests'] = event.guests;
+      if (event.minStarRating != null) filters['minStarRating'] = event.minStarRating;
+      if (event.requiredAmenities != null) filters['requiredAmenities'] = event.requiredAmenities;
+      if (event.unitTypeId != null) filters['unitTypeId'] = event.unitTypeId;
+      if (event.serviceIds != null) filters['serviceIds'] = event.serviceIds;
+      if (event.dynamicFieldFilters != null) filters['dynamicFieldFilters'] = event.dynamicFieldFilters;
+      if (event.checkIn != null) filters['checkIn'] = event.checkIn;
+      if (event.checkOut != null) filters['checkOut'] = event.checkOut;
+      if (event.guestsCount != null) filters['guestsCount'] = event.guestsCount;
       if (event.latitude != null) filters['latitude'] = event.latitude;
       if (event.longitude != null) filters['longitude'] = event.longitude;
       if (event.radiusKm != null) filters['radiusKm'] = event.radiusKm;
       if (event.sortBy != null) filters['sortBy'] = event.sortBy;
     } else if (event is UpdateSearchFiltersEvent) {
       if (event.city != null) filters['city'] = event.city;
-      if (event.propertyType != null) filters['propertyType'] = event.propertyType;
+      if (event.propertyTypeId != null) filters['propertyTypeId'] = event.propertyTypeId;
       if (event.minPrice != null) filters['minPrice'] = event.minPrice;
       if (event.maxPrice != null) filters['maxPrice'] = event.maxPrice;
-      if (event.minRating != null) filters['minRating'] = event.minRating;
-      if (event.amenities != null) filters['amenities'] = event.amenities;
-      if (event.checkInDate != null) filters['checkInDate'] = event.checkInDate;
-      if (event.checkOutDate != null) filters['checkOutDate'] = event.checkOutDate;
-      if (event.guests != null) filters['guests'] = event.guests;
+      if (event.minStarRating != null) filters['minStarRating'] = event.minStarRating;
+      if (event.requiredAmenities != null) filters['requiredAmenities'] = event.requiredAmenities;
+      if (event.checkIn != null) filters['checkIn'] = event.checkIn;
+      if (event.checkOut != null) filters['checkOut'] = event.checkOut;
+      if (event.guestsCount != null) filters['guestsCount'] = event.guestsCount;
       if (event.sortBy != null) filters['sortBy'] = event.sortBy;
     }
     

--- a/yemen_booking_app/lib/features/search/presentation/bloc/search_event.dart
+++ b/yemen_booking_app/lib/features/search/presentation/bloc/search_event.dart
@@ -8,16 +8,19 @@ abstract class SearchEvent extends Equatable {
 }
 
 class SearchPropertiesEvent extends SearchEvent {
-  final String? searchQuery;
+  final String? searchTerm;
   final String? city;
-  final String? propertyType;
+  final String? propertyTypeId;
   final double? minPrice;
   final double? maxPrice;
-  final int? minRating;
-  final List<String>? amenities;
-  final DateTime? checkInDate;
-  final DateTime? checkOutDate;
-  final int? guests;
+  final int? minStarRating;
+  final List<String>? requiredAmenities;
+  final String? unitTypeId;
+  final List<String>? serviceIds;
+  final Map<String, dynamic>? dynamicFieldFilters;
+  final DateTime? checkIn;
+  final DateTime? checkOut;
+  final int? guestsCount;
   final double? latitude;
   final double? longitude;
   final double? radiusKm;
@@ -27,16 +30,19 @@ class SearchPropertiesEvent extends SearchEvent {
   final bool isNewSearch;
 
   const SearchPropertiesEvent({
-    this.searchQuery,
+    this.searchTerm,
     this.city,
-    this.propertyType,
+    this.propertyTypeId,
     this.minPrice,
     this.maxPrice,
-    this.minRating,
-    this.amenities,
-    this.checkInDate,
-    this.checkOutDate,
-    this.guests,
+    this.minStarRating,
+    this.requiredAmenities,
+    this.unitTypeId,
+    this.serviceIds,
+    this.dynamicFieldFilters,
+    this.checkIn,
+    this.checkOut,
+    this.guestsCount,
     this.latitude,
     this.longitude,
     this.radiusKm,
@@ -48,16 +54,19 @@ class SearchPropertiesEvent extends SearchEvent {
 
   @override
   List<Object?> get props => [
-        searchQuery,
+        searchTerm,
         city,
-        propertyType,
+        propertyTypeId,
         minPrice,
         maxPrice,
-        minRating,
-        amenities,
-        checkInDate,
-        checkOutDate,
-        guests,
+        minStarRating,
+        requiredAmenities,
+        unitTypeId,
+        serviceIds,
+        dynamicFieldFilters,
+        checkIn,
+        checkOut,
+        guestsCount,
         latitude,
         longitude,
         radiusKm,
@@ -119,40 +128,40 @@ class GetPopularDestinationsEvent extends SearchEvent {
 
 class UpdateSearchFiltersEvent extends SearchEvent {
   final String? city;
-  final String? propertyType;
+  final String? propertyTypeId;
   final double? minPrice;
   final double? maxPrice;
-  final int? minRating;
-  final List<String>? amenities;
-  final DateTime? checkInDate;
-  final DateTime? checkOutDate;
-  final int? guests;
+  final int? minStarRating;
+  final List<String>? requiredAmenities;
+  final DateTime? checkIn;
+  final DateTime? checkOut;
+  final int? guestsCount;
   final String? sortBy;
 
   const UpdateSearchFiltersEvent({
     this.city,
-    this.propertyType,
+    this.propertyTypeId,
     this.minPrice,
     this.maxPrice,
-    this.minRating,
-    this.amenities,
-    this.checkInDate,
-    this.checkOutDate,
-    this.guests,
+    this.minStarRating,
+    this.requiredAmenities,
+    this.checkIn,
+    this.checkOut,
+    this.guestsCount,
     this.sortBy,
   });
 
   @override
   List<Object?> get props => [
         city,
-        propertyType,
+        propertyTypeId,
         minPrice,
         maxPrice,
-        minRating,
-        amenities,
-        checkInDate,
-        checkOutDate,
-        guests,
+        minStarRating,
+        requiredAmenities,
+        checkIn,
+        checkOut,
+        guestsCount,
         sortBy,
       ];
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Align search BLoC with backend API changes to ensure 100% compatibility.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR updates the `SearchBloc` to use the new parameter names and structures (`searchTerm`, `propertyTypeId`, `minStarRating`, `requiredAmenities`, `guestsCount`, etc.) that were previously aligned in the data source, repository, and use-case layers. This ensures the entire search feature from the presentation layer down to the backend API is fully consistent.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-46c2f41a-209a-463c-aa6e-fa0eefdef6b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents%3Fid=bc-46c2f41a-209a-463c-aa6e-fa0eefdef6b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>