### PR TITLE
Fix automapper booking dto inheritance

### DIFF
--- a/backend/YemenBooking.Application/Mappings/QueryMappingProfile.cs
+++ b/backend/YemenBooking.Application/Mappings/QueryMappingProfile.cs
@@ -29,7 +29,6 @@ namespace YemenBooking.Application.Mappings
 
             // Booking details including payments and services
             CreateMap<Booking, BookingDetailsDto>()
-                .IncludeBase<Booking, BookingDto>()
                 .ForMember(dest => dest.PaymentDetails, opt => opt.MapFrom(src => src.Payments))
                 .ForMember(dest => dest.ContactInfo, opt => opt.MapFrom(src => new ContactInfoDto { PhoneNumber = src.User.Phone ?? "", Email = src.User.Email ?? "" }));
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove incorrect AutoMapper `IncludeBase` mapping for `BookingDetailsDto` to fix a configuration error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `BookingDetailsDto` was incorrectly configured to include base mappings from `BookingDto`. However, `BookingDetailsDto` does not inherit from `BookingDto`, which caused an `ArgumentOutOfRangeException` during AutoMapper initialization, preventing the application from loading correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ca5c239-8700-40ae-bec7-15afc46719e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ca5c239-8700-40ae-bec7-15afc46719e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>