### PR TITLE
Fix dynamic home screen template fetching and build errors

### DIFF
--- a/frontend/src/hooks/useHomeScreenBuilder.ts
+++ b/frontend/src/hooks/useHomeScreenBuilder.ts
@@ -35,12 +35,17 @@ export const useHomeScreenBuilder = (options: UseHomeScreenBuilderOptions = {}) 
   const [isDirty, setIsDirty] = useState(false);
   const [lastSaveTime, setLastSaveTime] = useState<Date | null>(null);
 
-  // Fetch template data
-  const { data: template, isLoading: templateLoading, error: templateError } = useQuery<HomeScreenTemplate | null, Error>({
-    queryKey: ['homeScreenTemplate', templateId],
-    queryFn: () => templateId ? homeScreenService.getTemplateById(templateId) : null,
-    enabled: !!templateId
-  });
+  // Fetch template data with proper type inference
+  const { data: template, isLoading: templateLoading, error: templateError } = useQuery<HomeScreenTemplate | null, Error>(
+    ['homeScreenTemplate', templateId],
+    async () => {
+      if (!templateId) {
+        return null;
+      }
+      return homeScreenService.getTemplateById(templateId);
+    },
+    { enabled: !!templateId }
+  );
 
   // Fetch component types
   const { data: componentTypes = [] } = useQuery({

--- a/frontend/src/services/homeScreenService.ts
+++ b/frontend/src/services/homeScreenService.ts
@@ -24,7 +24,10 @@ export class HomeScreenService {
     isActive?: boolean;
     includeDeleted?: boolean;
   }): Promise<HomeScreenTemplate[]> {
-    const response = await apiClient.get(`${API_BASE_URL}/home-screens/templates`, { params });
+    const { platform = 'All', targetAudience = 'All', isActive, includeDeleted } = params || {};
+    const response = await apiClient.get(`${API_BASE_URL}/home-screens/templates`, {
+      params: { platform, targetAudience, isActive, includeDeleted }
+    });
     return response.data.data;
   }
 


### PR DESCRIPTION
Fixes 400 Bad Request for home screen templates by adding default query parameters and resolves TypeScript error by improving `useQuery` type inference.

The 400 error occurred because the backend API for fetching home screen templates requires `platform` and `targetAudience` query parameters, which were not always sent. The TypeScript error `Property 'id' does not exist on type 'never'` was due to `useQuery` not correctly inferring the type of `template` when `templateId` was optional, which is now resolved by using explicit generics and the function-overload form.

---
<a href="https://cursor.com/background-agent?bcId=bc-399af685-bcc6-48fc-a1fc-32a02f075e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-399af685-bcc6-48fc-a1fc-32a02f075e52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>