### PR TITLE
Fix missing main sections page in side menu

### DIFF
--- a/frontend/src/components/layout/ModernDashboardLayout.tsx
+++ b/frontend/src/components/layout/ModernDashboardLayout.tsx
@@ -214,8 +214,8 @@ const ModernDashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => 
     },
     // إدارة الصفحة الرئيسية الديناميكية
     {
-      path: '/admin/home-screen-builder',
-      label: 'إدارة الصفحة الرئيسية الديناميكية',
+      path: '/admin/home-sections',
+      label: 'إدارة أقسام الصفحة الرئيسية',
       icon: (
         <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 3h7v7H3V3zm11 0h7v7h-7V3zM3 14h7v7H3v-7zm11 0h7v7h-7v-7z" />


### PR DESCRIPTION
Corrects the sidebar navigation path and label for the home sections management page to ensure it appears and functions correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-11c887df-ea03-4e32-ac26-edbb39f13172">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11c887df-ea03-4e32-ac26-edbb39f13172">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

