### PR TITLE
Fix home sections api errors

### DIFF
--- a/frontend/src/services/homeSectionsService.ts
+++ b/frontend/src/services/homeSectionsService.ts
@@ -22,8 +22,8 @@ import type {
 } from '../types/homeSections.types';
 
 // Base URLs for Home Sections admin and client endpoints
-const ADMIN_BASE = '/api/admin/HomeSections';
-const CLIENT_BASE = '/api/client/homeSections';
+const ADMIN_BASE = '/api/admin/home-sections';
+const CLIENT_BASE = '/api/client/home-sections';
 
 class HomeSectionsService {
   // Dynamic Sections (Admin)


### PR DESCRIPTION
Fix 404 errors on Home Sections admin page by correcting API endpoint casing in frontend.

The backend API uses kebab-case for routes (e.g., `/home-sections`) due to `RouteTokenTransformerConvention`, but the frontend was requesting PascalCase (e.g., `/HomeSections`), leading to 404 Not Found errors. This PR updates the frontend service URLs to match the backend's kebab-case.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc43a9ac-8a3b-4e82-b9d9-2cfe155c6320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc43a9ac-8a3b-4e82-b9d9-2cfe155c6320">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

